### PR TITLE
Use the default set of HLint hints

### DIFF
--- a/src/features/validationProvider.ts
+++ b/src/features/validationProvider.ts
@@ -57,7 +57,7 @@ export class LineDecoder {
 
 export default class HaskellValidationProvider {
 
-	private static FileArgs: string[] = ['--json', '--hint=Default', '--hint=Dollar', '--hint=Generalise'];
+	private static FileArgs: string[] = ['--json'];
 
 	private executable: string;
 	private executableNotFound: boolean;


### PR DESCRIPTION
- By not specifying a set of hints on the command line, hlint will use its full set of default hints
