### PR TITLE
Add stack support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
                     "default": "hlint",
                     "description": "Points to the hlint exectuable."
                 },
+                "haskell.hlint.useStack": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to use `stack exec` to find the executable."
+                },
                 "haskell.hlint.run": {
                     "type": "string",
                     "enum": [


### PR DESCRIPTION
This adds a new configuration option, `useStack`. When set to true, `stack exec` will be used instead of directly searching for `hlint` in the path. This resolves #17.