### PR TITLE
Title for configuration options

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
             }
         ],
         "configuration": {
-            "title": "",
+            "title": "Haskell Linter",
             "properties": {
                 "haskell.hlint.executablePath": {
                     "type": "string",


### PR DESCRIPTION
### Before:
![Configuration heading is "hoovercj.haskell-linter"](https://user-images.githubusercontent.com/2198220/29687430-488c246e-88d1-11e7-9b20-16eb7adf98e1.png)

### After:
![Configuration heading is "Haskell Linter"](https://user-images.githubusercontent.com/2198220/29687433-4d08a062-88d1-11e7-97fb-fdf45e200bef.png)
