### PR TITLE
Interpret HLint suggestions as VS Code warnings, not errors

### DIFF
--- a/src/features/hlintProvider.ts
+++ b/src/features/hlintProvider.ts
@@ -306,6 +306,7 @@ export default class HaskellLintingProvider implements vscode.CodeActionProvider
 
     private static _asDiagnosticSeverity(logLevel: string): vscode.DiagnosticSeverity {
         switch (logLevel.toLowerCase()) {
+            case 'suggestion':
             case 'warning':
                 return vscode.DiagnosticSeverity.Warning;
             default:


### PR DESCRIPTION
Fixes #25.