### PR TITLE
Match hlint and vscode log levels

### DIFF
--- a/src/features/hlintProvider.ts
+++ b/src/features/hlintProvider.ts
@@ -307,10 +307,13 @@ export default class HaskellLintingProvider implements vscode.CodeActionProvider
     private static _asDiagnosticSeverity(logLevel: string): vscode.DiagnosticSeverity {
         switch (logLevel.toLowerCase()) {
             case 'suggestion':
+                return vscode.DiagnosticSeverity.Hint;
             case 'warning':
                 return vscode.DiagnosticSeverity.Warning;
-            default:
+            case 'error':
                 return vscode.DiagnosticSeverity.Error;
+            default:
+                return vscode.DiagnosticSeverity.Information;
         }
     }
 


### PR DESCRIPTION
The vscode diagnostic severity should (in my opinion and by default) match the hlint output. This change will make suggestions less prominent.

Because the actual visualization (dots, yellow squiggle, red squiggle) might be a matter of personal preference, it would be handy to make this configurable in the future.
